### PR TITLE
docs: add stop() method documentation to README API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tiny EventSource simplifies server-sent events (SSE) for API servers. An EventEm
   - [send()](#sendmsg-event-id)
   - [listenerCount()](#listenercountevent)
   - [setMaxListeners()](#setmaxlistenersn)
+  - [stop()](#stop)
 - [Options](#options)
 - [Events](#events)
   - [close](#close)
@@ -157,6 +158,16 @@ stream.setMaxListeners(0);
 | Parameter | Type     | Required | Description                                      |
 | --------- | -------- | -------- | ------------------------------------------------ |
 | n         | `number` | yes      | Maximum number of listeners; `0` means unlimited |
+
+**Returns:** `this` (`EventSource`)
+
+### stop()
+
+Stops the heartbeat interval if one is active.
+
+```javascript
+stream.stop();
+```
 
 **Returns:** `this` (`EventSource`)
 


### PR DESCRIPTION
## Summary

Adds the `stop()` method documentation to the README API section to match the `EventSource` class in `src/eventsource.js`.

## Type of Change

- [x] Documentation update

## Testing

N/A — README documentation change only, no code modifications.

## Coverage

- [x] 100% line coverage maintained

## Checklist

- [x] `npm run lint` passes
- [x] Tests pass with 100% line coverage
- [x] No forbidden patterns used
- [x] Conventional Commit style applied