### PR TITLE
fix: add node:events as rollup external

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ const esmOutBase = { ...defaultOutBase, format: "esm" };
 export default [
 	{
 		input: "./src/eventsource.js",
+		external: ["node:events"],
 		output: [
 			{
 				...cjOutBase,


### PR DESCRIPTION
Add `node:events` to rollup externals to suppress the `Unresolved dependencies` warning when bundling.